### PR TITLE
Fix the charts-manager port (relates to SAAS-5905)

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -17,7 +17,6 @@ global:
   #appUrl: g.apps-os-t2.cf-cd.com
   appUrl: codefresh-dev.v12.np01.ocp.six-group.net
 
-  chartsManagerPort: 8080
   clusterProvidersPort: 8080
   kubeIntegrationPort: 8080
   runtimeEnvironmentManagerPort: 8080
@@ -85,9 +84,6 @@ cf-broadcaster:
       memory: 128Mi
 
 cfui:
-  port: 8080
-
-charts-manager:
   port: 8080
 
 cluster-providers:


### PR DESCRIPTION
Currently the charts-manager service specification contains incorrect values: targetPort is 9000, whereas the application listens on 8080

This commit removes the port values from the global values file making the chart-manager templates to use the values inside the chart, thus fixing the problem in the produced helm release