### PR TITLE
Remove no hooks flag

### DIFF
--- a/cf-onprem
+++ b/cf-onprem
@@ -297,7 +297,6 @@ if [[ -z "$DO_TEMPLATE" ]]; then
     --namespace "${NAMESPACE}" \
     --values "${VALUES_FILE}" \
     --values "${DOCKER_CFG_YAML}" \
-    --no-hooks \
     --set cfapi.redeploy=true \
     ${SET_WEBTLS_VALUES} \
     ${SEEDJOBS} \


### PR DESCRIPTION
We need to remove the --no-hooks flag from the helm upgrade flag, because we need to run a pre-upgrade hook, which updates the default runtimes with the newer image versions (SAAS-7499)